### PR TITLE
#1 3 IOライブラリのvector用print処理を修正・追加

### DIFF
--- a/FastIO/CommonIO.hpp
+++ b/FastIO/CommonIO.hpp
@@ -27,32 +27,40 @@ public:
     }
     template <class T>
     void print(std::vector<T> &v) {
-        for (T t: v) {
-            print(t);
-            print(" ");
+        if (v.size() == 0) return;
+        print(*v.begin());
+        for (auto it = ++v.begin(); it != v.end(); ++it) {
+            print(' ');
+            print(*it);
         }
-        print("\n");
+    }
+    template <class T>
+    void print(std::vector< std::vector<T> > &grid) {
+        if (grid.size() == 0) return;
+        print(*grid.begin());
+        for (auto it = ++grid.begin(); it != grid.end(); ++it) {
+            print('\n');
+            print(*it);
+        }
     }
     template <class T, class... Rest>
     void print(T v, Rest... rest) {
         print(v);
-        print(" ");
+        print(' ');
         print(rest...);
     }
 
     template <class T>
     void printl(T v) {
         print(v);
-        std::cout << "\n";
+        std::cout << '\n';
     }
     template <class T, class... Rest>
     void printl(T v, Rest... rest) {
         print(v);
-        print(" ");
+        print(' ');
         printl(rest...);
     }
-};
-
-CommonIO io;
+} io;
 
 #endif //FORCP_FASTIO_HPP

--- a/FastIO/FastIO.hpp
+++ b/FastIO/FastIO.hpp
@@ -175,11 +175,12 @@ public:
     void print(ull x) {PrintNatural(x);}
     template <class T>
     void print(std::vector<T> &v) {
-        for (auto i: v) {
-            print(i);
+        if (v.size() == 0) return;
+        print(*v.begin());
+        for (auto it = ++v.begin(); it != v.end(); ++it) {
             PutChar(' ');
+            print(*it);
         }
-        PutChar('\n');
     }
     template<typename First, typename ... Ints>
     void print(First arg, Ints... rest) {

--- a/FastIO/FastIO.hpp
+++ b/FastIO/FastIO.hpp
@@ -182,6 +182,15 @@ public:
             print(*it);
         }
     }
+    template <class T>
+    void print(std::vector< std::vector<T> > &grid) {
+        if (grid.size() == 0) return;
+        print(*grid.begin());
+        for (auto it = ++grid.begin(); it != grid.end(); ++it) {
+            PutChar('\n');
+            print(*it);
+        }
+    }
     template<typename First, typename ... Ints>
     void print(First arg, Ints... rest) {
         print(arg);

--- a/FastIO/FastIO.hpp
+++ b/FastIO/FastIO.hpp
@@ -211,8 +211,6 @@ public:
 
     void SayYes() {PrintString("Yes\n", 4);}
     void SayNo() {PrintString("No\n", 3);}
-};
-
-FastIO io;
+} io;
 
 #endif //FORCP_FASTIO_HPP


### PR DESCRIPTION
変更点
- vectorをprintしたときの末尾に余分な空白と改行が入らなくなった
- 2次元vector用のprint処理を追加
- ioインスタンス作成文の簡略化
- CommonIOでcharで良いところが文字列になっていた部分をcharにした